### PR TITLE
Added migrations

### DIFF
--- a/src/shared/types/database.types.ts
+++ b/src/shared/types/database.types.ts
@@ -2606,6 +2606,7 @@ export type Database = {
           created_at: string
           end_at: string
           id: string
+          job_id: string | null
           job_number: string | null
           note: string | null
           start_at: string
@@ -2618,6 +2619,7 @@ export type Database = {
           created_at?: string
           end_at: string
           id?: string
+          job_id?: string | null
           job_number?: string | null
           note?: string | null
           start_at: string
@@ -2630,6 +2632,7 @@ export type Database = {
           created_at?: string
           end_at?: string
           id?: string
+          job_id?: string | null
           job_number?: string | null
           note?: string | null
           start_at?: string
@@ -2643,6 +2646,13 @@ export type Database = {
             columns: ["company_id"]
             isOneToOne: false
             referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "time_entries_job_id_fkey"
+            columns: ["job_id"]
+            isOneToOne: false
+            referencedRelation: "jobs"
             referencedColumns: ["id"]
           },
           {

--- a/supabase/migrations/20260201095500_allow_freelancers_read_all_time_periods_for_their_jobs.sql
+++ b/supabase/migrations/20260201095500_allow_freelancers_read_all_time_periods_for_their_jobs.sql
@@ -57,6 +57,7 @@ $$;
 
 -- Replace the old freelancer time_periods policy with job-scoped access.
 DROP POLICY IF EXISTS "Freelancers can view time_periods they are invited to" ON public.time_periods;
+DROP POLICY IF EXISTS "Freelancers can view time_periods for their jobs" ON public.time_periods;
 CREATE POLICY "Freelancers can view time_periods for their jobs"
   ON public.time_periods
   FOR SELECT

--- a/supabase/migrations/20260209130000_add_job_id_to_time_entries.sql
+++ b/supabase/migrations/20260209130000_add_job_id_to_time_entries.sql
@@ -1,0 +1,8 @@
+-- Add job_id to time_entries so entries can be linked to a job
+
+ALTER TABLE time_entries
+  ADD COLUMN IF NOT EXISTS job_id UUID REFERENCES jobs(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_time_entries_job_id ON time_entries(job_id);
+
+COMMENT ON COLUMN time_entries.job_id IS 'Optional link to a job when logging time against a specific job';


### PR DESCRIPTION
## Description

Brief description of changes in this PR.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Database migration
- [ ] Refactoring
- [ ] Documentation

## Database Changes

- [ ] No database changes
- [ ] Migration created: `YYYYMMDDHHMMSS_description.sql`
- [ ] Migration tested locally (`npm run db:reset`)
- [ ] Migration pushed to production (if backward-compatible)
- [ ] Types updated (`npm run db:types:remote`)
- [ ] Types file committed

**Migration Details** (if applicable):

- Migration file: `supabase/migrations/YYYYMMDDHHMMSS_description.sql`
- Backward compatible: Yes/No
- RLS policies added: Yes/No

## Testing

- [ ] Tested locally
- [ ] Tested with local database
- [ ] Tested with production database (read-only)
- [ ] RLS policies verified with different user roles
- [ ] No console errors or warnings
- [ ] Build succeeds (`npm run build`)

## Checklist

- [ ] Code follows project patterns
- [ ] TypeScript types updated (if schema changed)
- [ ] No breaking changes (or clearly documented)
- [ ] Environment variables documented (if new ones added)
- [ ] Migration files committed
- [ ] Ready to merge to `main`

## Deployment Notes

Any special considerations for deployment:

- [ ] Migration needs to be pushed before merging
- [ ] Migration needs to be pushed after merging
- [ ] No special deployment steps needed

## Related Issues

Closes #(issue number)

---

**Before merging, ensure:**

1. All migrations are tested and pushed (if backward-compatible)
2. TypeScript types are updated and committed
3. Build succeeds without errors
4. All checklist items are completed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Includes schema and RLS policy changes; incorrect policy logic could unintentionally broaden or restrict freelancer visibility into `time_periods`.
> 
> **Overview**
> Adds an optional `job_id` foreign key to `time_entries` (with index) so time logs can be associated with a specific `jobs` record, and updates generated `database.types.ts` accordingly.
> 
> Updates the `time_periods` RLS setup by (re)creating `can_freelancer_view_job(...)` and replacing the freelancer SELECT policy with a job-scoped policy, ensuring old policies are dropped before re-creation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e41b9adc2efcb2e351917778edcf6749a6fd729f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->