### PR TITLE
fix: restore CI e2e after calendar and mobile jobs UI changes

### DIFF
--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -8,10 +8,7 @@ test.describe('Calendar', () => {
     test.setTimeout(60_000)
     await openCalendarPage(page)
 
-    const categorySelect = page
-      .getByText('Category:', { exact: true })
-      .locator('..')
-      .getByRole('combobox')
+    const categorySelect = page.getByRole('combobox', { name: 'Category' })
     await expect(categorySelect).toContainText('Jobs')
     await categorySelect.click()
     await page.getByRole('option', { name: 'Equipment' }).click()

--- a/e2e/helpers/navigation.ts
+++ b/e2e/helpers/navigation.ts
@@ -24,6 +24,23 @@ async function closeMobileMenuIfOpen(page: Page) {
   }
 }
 
+/** Close the phone inspector so list chrome (e.g. New job) is visible again. */
+async function closeMobileInspectorIfOpen(page: Page) {
+  const closeInspector = page.getByRole('button', { name: 'Close inspector' })
+  if (await closeInspector.isVisible().catch(() => false)) {
+    await closeInspector.click({ force: true })
+    await expect(closeInspector).toBeHidden({ timeout: 5_000 })
+  }
+
+  const inspectorBackdrop = page.locator(
+    '.app-inspector-backdrop[data-open="true"]',
+  )
+  if (await inspectorBackdrop.isVisible().catch(() => false)) {
+    await inspectorBackdrop.click({ force: true })
+    await expect(inspectorBackdrop).toBeHidden({ timeout: 5_000 })
+  }
+}
+
 /** Dismiss auto-opened release notes so the popover cannot intercept nav clicks. */
 async function dismissWhatsNewIfOpen(page: Page) {
   const gotIt = page.getByRole('button', { name: 'Got it' })
@@ -137,16 +154,14 @@ function tabSectionButton(page: Page) {
 }
 
 export async function openJobsPage(page: Page) {
-  const inspectorBackdrop = page.locator(
-    '.app-inspector-backdrop[data-open="true"]',
-  )
-  if (await inspectorBackdrop.isVisible().catch(() => false)) {
-    await inspectorBackdrop.click({ force: true })
-  }
+  await closeMobileInspectorIfOpen(page)
 
   if (!/\/jobs(?:\?|$)/.test(new URL(page.url()).pathname)) {
     await clickNavLink(page, 'Jobs')
   }
+
+  await closeMobileInspectorIfOpen(page)
+  await closeMobileMenuIfOpen(page)
 
   await expect(page).toHaveURL(/\/jobs/, { timeout: 15_000 })
   await expect(
@@ -182,7 +197,7 @@ export async function openCustomersPage(page: Page) {
 export async function openCalendarPage(page: Page) {
   await clickNavLink(page, 'Calendar')
   await expect(page).toHaveURL(/\/calendar/, { timeout: 15_000 })
-  await expect(page.getByText('Category:', { exact: true })).toBeVisible({
+  await expect(page.getByRole('combobox', { name: 'Category' })).toBeVisible({
     timeout: 15_000,
   })
 }

--- a/e2e/jobs.spec.ts
+++ b/e2e/jobs.spec.ts
@@ -67,7 +67,7 @@ test.describe('Jobs', () => {
     await openJobsPage(page)
     await expect(
       page.getByRole('button', { name: 'New job' }).first(),
-    ).toBeVisible()
+    ).toBeVisible({ timeout: 15_000 })
   })
 
   test('owner can change job status from overview timeline', async ({


### PR DESCRIPTION
## Summary
- Calendar E2E was still looking for a `Category:` text label after the filter became an unlabeled combobox (`aria-label="Category"`).
- Mobile jobs E2E expected `New job` while the inspector was still open, which hides the bottom action bar.
- Helpers now wait on the category combobox, close the inspector before asserting list chrome, and the previously failing specs pass locally.

## Test plan
- [x] `npx playwright test e2e/calendar.spec.ts e2e/roles.spec.ts e2e/jobs.spec.ts -g "owner can filter calendar|freelancer can access jobs and calendar|owner can return to jobs list"` — 6 passed
- [ ] GitHub CI unit, build, storybook, integration, and e2e jobs go green


Made with [Cursor](https://cursor.com)