### PR TITLE
Add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,17 @@
+{
+  "name": "Grid",
+  "install": "bash scripts/cloud-agent-install.sh",
+  "start": "bash scripts/cloud-agent-start.sh",
+  "terminals": [
+    {
+      "name": "dev",
+      "command": "npm run dev",
+      "description": "Vite dev server for the Grid app on http://localhost:3000 (reads .env.local written by the start script)."
+    }
+  ],
+  "ports": [
+    { "name": "app", "port": 3000 },
+    { "name": "supabase-api", "port": 54321 },
+    { "name": "supabase-studio", "port": 54323 }
+  ]
+}

--- a/scripts/cloud-agent-install.sh
+++ b/scripts/cloud-agent-install.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Cloud Agent environment install script.
+#
+# Runs once after the repository is checked out (and again when dependencies
+# need refreshing). Prepares durable, source-derived state:
+#   - Node dependencies (npm ci)
+#   - Docker Engine + fuse-overlayfs (needed to run the local Supabase stack
+#     inside the nested Cloud Agent VM)
+#   - Supabase CLI on the system PATH
+#
+# Must be idempotent and terminate. Per-boot services (dockerd, Supabase, the
+# dev server) are started from cloud-agent-start.sh / terminals, not here.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+echo "[cloud-agent-install] installing Node dependencies"
+npm ci
+
+echo "[cloud-agent-install] installing Docker + fuse-overlayfs"
+export DEBIAN_FRONTEND=noninteractive
+sudo apt-get update -qq
+# fuse3 ships an /etc/fuse.conf conffile whose interactive prompt can wedge
+# dpkg; force the non-interactive default so the install always completes.
+sudo apt-get install -y -qq \
+  -o Dpkg::Options::=--force-confdef \
+  -o Dpkg::Options::=--force-confold \
+  docker.io fuse-overlayfs uidmap
+sudo dpkg --configure -a --force-confdef --force-confold || true
+
+echo "[cloud-agent-install] configuring Docker daemon for the nested VM"
+# The VM's root filesystem is already an overlay mount, so Docker's default
+# native overlay2 driver cannot mount overlay-on-overlay (fails with
+# "invalid argument"). fuse-overlayfs works. Docker 29 also defaults to the
+# nftables firewall backend, whose bridge NAT rules do not apply here and
+# break container-to-container networking; iptables-legacy works.
+sudo mkdir -p /etc/docker
+sudo tee /etc/docker/daemon.json >/dev/null <<'JSON'
+{
+  "features": { "containerd-snapshotter": false },
+  "storage-driver": "fuse-overlayfs",
+  "firewall-backend": "iptables"
+}
+JSON
+
+sudo update-alternatives --set iptables /usr/sbin/iptables-legacy
+sudo update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+
+# Let the agent user talk to the Docker socket without sudo.
+sudo groupadd -f docker
+sudo usermod -aG docker "$(id -un)" || true
+
+echo "[cloud-agent-install] exposing Supabase CLI on the system PATH"
+# The db scripts intentionally call `supabase` from the system PATH (they strip
+# node_modules/.bin), so symlink the CLI binary npm installed into /usr/local/bin.
+SUPABASE_BIN="$(pwd)/node_modules/@supabase/cli-linux-x64/bin/supabase"
+if [ -x "$SUPABASE_BIN" ]; then
+  sudo ln -sf "$SUPABASE_BIN" /usr/local/bin/supabase
+else
+  echo "[cloud-agent-install] WARNING: supabase CLI binary not found at $SUPABASE_BIN" >&2
+fi
+
+echo "[cloud-agent-install] done"

--- a/scripts/cloud-agent-start.sh
+++ b/scripts/cloud-agent-start.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Cloud Agent environment start script.
+#
+# Runs on every boot to bring up per-boot runtime state that does not survive
+# across VM boots:
+#   - the Docker daemon
+#   - the local Supabase stack
+#   - a fresh, deterministic database (migrations + seed.sql + test users)
+#   - .env.local pointing the app at the local Supabase instance
+#
+# Must be idempotent, tolerate restarts, and return (the long-running Vite dev
+# server is started separately as a terminal). The dev server reads .env.local,
+# which this script writes before it returns.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+log() { echo "[cloud-agent-start] $*"; }
+
+# --- Docker daemon -----------------------------------------------------------
+if ! sudo docker info >/dev/null 2>&1; then
+  log "starting dockerd"
+  sudo update-alternatives --set iptables /usr/sbin/iptables-legacy >/dev/null 2>&1 || true
+  sudo update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy >/dev/null 2>&1 || true
+  sudo nohup dockerd >/tmp/dockerd.log 2>&1 &
+  for _ in $(seq 1 60); do
+    sudo docker info >/dev/null 2>&1 && break
+    sleep 1
+  done
+fi
+# Allow non-root access to the socket (Supabase CLI shells out to `docker`).
+sudo chmod 666 /var/run/docker.sock || true
+if ! docker info >/dev/null 2>&1; then
+  log "ERROR: Docker daemon did not come up"
+  sudo tail -n 40 /tmp/dockerd.log || true
+  exit 1
+fi
+log "Docker is up"
+
+# --- Supabase local stack ----------------------------------------------------
+# imgproxy/logflare/vector are excluded (not needed for local dev, matches CI).
+if ! supabase status >/dev/null 2>&1; then
+  log "starting Supabase stack"
+  supabase start -x imgproxy,logflare,vector
+else
+  log "Supabase already running"
+fi
+
+# --- Database: migrations + seed.sql + deterministic test users --------------
+log "applying migrations and seed.sql (supabase db reset)"
+supabase db reset
+
+eval "$(supabase status -o env | sed 's/^/export /')"
+export SUPABASE_URL="$API_URL" \
+       VITE_SUPABASE_URL="$API_URL" \
+       VITE_SUPABASE_ANON_KEY="$ANON_KEY" \
+       SUPABASE_SERVICE_ROLE_KEY="$SERVICE_ROLE_KEY"
+
+log "seeding test users and demo data"
+npm run db:seed-test-users
+
+# --- App environment file ----------------------------------------------------
+log "writing .env.local"
+cat > .env.local <<ENV
+VITE_SUPABASE_URL=$API_URL
+VITE_SUPABASE_ANON_KEY=$ANON_KEY
+SUPABASE_PROJECT_REF=tlpgejkglrgoljgvpubn
+ENV
+
+log "done — local Supabase API at $API_URL, Studio at ${STUDIO_URL:-http://127.0.0.1:54323}"
+log "test login: owner@test.grid.local / TestPassword123!"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up a self-contained Cloud Agent development environment for Grid. A fresh agent boots into the full local stack — Docker, a local Supabase instance (Postgres + Auth + REST + Storage + Studio), and the Vite dev server — with **no external secrets required**.

This mirrors how CI stands up the app (`supabase start` → `supabase db reset` → `db:seed-test-users`), so the environment is reproducible from source and versioned with the repo.

## What's included

- **`.cursor/environment.json`** — repo-managed environment config: `install`/`start` scripts, a `dev` terminal running the Vite server, and exposed ports (app `3000`, Supabase API `54321`, Studio `54323`).
- **`scripts/cloud-agent-install.sh`** — durable, idempotent setup: `npm ci`, install Docker + `fuse-overlayfs`, configure the Docker daemon for the nested VM, and put the Supabase CLI on the system `PATH`.
- **`scripts/cloud-agent-start.sh`** — per-boot startup: start `dockerd` + the local Supabase stack, apply migrations + `seed.sql`, seed deterministic test users, and write `.env.local` for the dev server.

## Nested-VM specifics

The Cloud Agent VM's root filesystem is already an overlay mount, so two Docker defaults had to change to run the Supabase containers:

- **Storage driver → `fuse-overlayfs`.** The native `overlay2` driver can't mount overlay-on-overlay (fails with `invalid argument`).
- **Firewall backend → `iptables` (legacy).** Docker 29 defaults to the nftables backend, whose bridge NAT rules don't apply here and break container-to-container networking (Realtime couldn't reach Postgres).

## Test login

`owner@test.grid.local` / `TestPassword123!`

## Validation

| Check | Result |
| --- | --- |
| Local Supabase stack (`supabase start`) | Up (API `:54321`, Studio `:54323`) |
| Migrations + seed (`supabase db reset`) | 200 migrations applied, seeded |
| Unit tests (`npm run test`) | 793 passed (135 files) |
| Integration tests (`npm run test:integration`) | 61 passed (11 files) |
| Production build (`npm run build:check`) | Passed (`vite build` + `tsc`) |
| App end-to-end (GUI) | Logged in as owner, browsed Dashboard/Jobs/Job detail/Calendar with seeded data |
| Install idempotence | Passed twice |
| Start idempotence | Passed (re-detects running Docker/Supabase) |

> Note: `.env.local` is written at boot by the start script and remains gitignored — no secrets are committed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b64d1551-3f66-4636-96e5-732c9d35cd49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b64d1551-3f66-4636-96e5-732c9d35cd49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

